### PR TITLE
fix: add explicit STL headers and tighten two non-portable usages

### DIFF
--- a/client/src/layoutboard.cpp
+++ b/client/src/layoutboard.cpp
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <ranges>
 #include <algorithm>
 #include <utf8.h>
 #include "colorf.hpp"

--- a/common/src/buffrecord.hpp
+++ b/common/src/buffrecord.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cmath>
 #include <string>
 #include <cstdint>
 #include <variant>

--- a/common/src/log.hpp
+++ b/common/src/log.hpp
@@ -3,6 +3,9 @@
 #include <string>
 #include <cstring>
 #include <iostream>
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
 #include <g3log/g3log.hpp>
 #include <g3log/logworker.hpp>
 

--- a/common/src/protocoldef.hpp
+++ b/common/src/protocoldef.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <utility>
 #include "motion.hpp"
 
 // define of directioin

--- a/common/src/sdruntimeconfig.hpp
+++ b/common/src/sdruntimeconfig.hpp
@@ -60,8 +60,16 @@ constexpr int RTCFG_NONE  = 0;
 constexpr int RTCFG_BEGIN = 1;
 
 constexpr int _RSVD_rtcfg_add_type_counter_begin = __COUNTER__;
-template<int            > auto SDRuntimeConfig_getConfig(const SDRuntimeConfig &           ) = delete;
-template<int, typename T> bool SDRuntimeConfig_setConfig(      SDRuntimeConfig &, const T &) = delete;
+template<int N> auto SDRuntimeConfig_getConfig(const SDRuntimeConfig &)
+{
+    static_assert(N != N, "unknown rtcfg key, register it via _MACRO_ADD_RTCFG_TYPE");
+    return char{};
+}
+template<int N, typename T> bool SDRuntimeConfig_setConfig(SDRuntimeConfig &, const T &)
+{
+    static_assert(N != N, "unknown rtcfg key, register it via _MACRO_ADD_RTCFG_TYPE");
+    return false;
+}
 
 #define _MACRO_ADD_RTCFG_TYPE(rtCfgKeyType, rtCfgValueType, rtCfgDefaultValue) \
     constexpr int rtCfgKeyType = __COUNTER__ - _RSVD_rtcfg_add_type_counter_begin; \

--- a/common/src/staticvector.hpp
+++ b/common/src/staticvector.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <span>
 #include <cstdint>
 #include <cstddef>
 #include <string>

--- a/common/src/triangle.cpp
+++ b/common/src/triangle.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "triangle.hpp"
 
 Triangle::Triangle(

--- a/common/src/zcompf.hpp
+++ b/common/src/zcompf.hpp
@@ -25,7 +25,7 @@ namespace zcompf
         dst.clear();
         dst.resize(maxDstSize);
 
-        const int compSize = LZ4_compress_default(reinterpret_cast<const char *>(src.data()), reinterpret_cast<char *>(dst.data()), srcSize * sizeof(T), maxDstSize);
+        const int compSize = LZ4_compress_default(reinterpret_cast<const char *>(src), reinterpret_cast<char *>(dst.data()), srcSize * sizeof(T), maxDstSize);
         if(compSize <= 0){
             throw fflerror("LZ4_compress_default() return error code: %d", compSize);
         }


### PR DESCRIPTION
GCC pulls a few common STL headers in transitively, and accepts a
couple of small non-portable patterns that Clang rejects. Apple
Clang and Clang in general do neither, so the project doesn't
compile out of the box on macOS / on a recent libc++ toolchain.

This PR is the minimal fix. None of these changes affect behaviour
or change Linux GCC builds.

### Header completeness (transitive on GCC, not on Clang)
- `common/src/triangle.cpp` — `<algorithm>` (`std::max` / `std::min`)
- `common/src/log.hpp` — `<unistd.h>` (`getpid()`)
- `common/src/buffrecord.hpp` — `<cmath>` (`std::lround`)
- `common/src/staticvector.hpp` — `<span>` (`std::span`)
- `common/src/protocoldef.hpp` — `<utility>` (`std::move` / `std::forward`)
- `client/src/layoutboard.cpp` — `<ranges>` (`std::views`)

### Standards-conformance fixes
- `common/src/sdruntimeconfig.hpp` — replace a `=delete`-on-template-
  specialization (a GCC extension) with `static_assert`. Clang
  requires `=delete` to appear on the first declaration of an
  entity; the existing form was non-standard.
- `common/src/zcompf.hpp` — pass `src` directly instead of
  `src.data()`; the parameter is already a raw `const uint8_t *`,
  so `.data()` doesn't compile.

### Tested
- Apple Clang 17 (Xcode 17) on macOS arm64 — builds clean.
- brew LLVM 22 on macOS arm64 — builds clean.
- Should be a strict no-op on Linux GCC builds (only adds includes
  and replaces non-portable patterns with portable equivalents).